### PR TITLE
Metamask Update Fix

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -62,6 +62,8 @@ class App extends Component {
   buyTokens = (etherAmount) => {
     this.setState({ loading: true })
     this.state.ethSwap.methods.buyTokens().send({ value: etherAmount, from: this.state.account }).on('transactionHash', (hash) => {
+    }).on('confirmation', (confNumber, receipt, latestBlockHash) => {
+      window.location.reload()
       this.setState({ loading: false })
     })
   }
@@ -70,8 +72,9 @@ class App extends Component {
     this.setState({ loading: true })
     this.state.token.methods.approve(this.state.ethSwap.address, tokenAmount).send({ from: this.state.account }).on('transactionHash', (hash) => {
       this.state.ethSwap.methods.sellTokens(tokenAmount).send({ from: this.state.account }).on('transactionHash', (hash) => {
+      }).on('confirmation', (confNumber, receipt, latestBlockHash) => {
+        window.location.reload()
         this.setState({ loading: false })
-      })
     })
   }
 


### PR DESCRIPTION
Metamask no longer automatically reloads the page upon received confirmations from the blockchain. This leads to the UI not reflecting the account balance changes after buying / selling.  Added the code to handle the "promiEvent" and update after confirmation to have accurate balance reflected after the transaction is confirmed. Check here for the web3.js documentation on "promiEvent" https://web3js.readthedocs.io/en/v1.5.2/callbacks-promises-events.html